### PR TITLE
Lowercase emails before hashing.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+0.1.4 (2018-07-23)
+------------------
+
+* normalize email address before hashing (PLAT-2254)
+
 0.1.1 (2018-03-29)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/edx/user-util',
-    version='0.1.3',
+    version='0.1.4',
     zip_safe=False,
 )

--- a/tests/test_user_util.py
+++ b/tests/test_user_util.py
@@ -141,6 +141,19 @@ def test_email_to_hash(salt_list):
     assert len(retired_email.split('@')[0]) == len('retired_email_') + 40
 
 
+@pytest.mark.parametrize('salt_list', VALID_SALT_LISTS)
+def test_email_to_hash_is_normalized(salt_list):
+    """
+    Make sure identical emails with different cases map to the same retired email.
+    """
+    email_mixed = 'A.Learner@example.com'
+    email_lower = email_mixed.lower()
+    retired_email_mixed = user_util.get_retired_email(email_mixed, salt_list)
+    retired_email_lower = user_util.get_retired_email(email_lower, salt_list)
+    # No matter the case of the input email, the retired email hash should be identical.
+    assert retired_email_mixed == retired_email_lower
+
+
 def test_unicode_email_to_hash():
     email = u'🅐.🅛🅔🅐🅡🅝🅔🅡r@example.com'
     retired_email = user_util.get_retired_email(email, VALID_SALT_LIST_ONE_SALT)

--- a/user_util/user_util.py
+++ b/user_util/user_util.py
@@ -47,9 +47,9 @@ def get_all_retired_usernames(username, salt_list, retired_username_fmt=RETIRED_
 
 def get_all_retired_emails(email, salt_list, retired_email_fmt=RETIRED_EMAIL_DEFAULT_FMT):
     """
-    Returns a generator of possible retired email addresses based on the original email
-    and all the historical salts, from oldest to current.
-    The current salt is assumed to be the last salt in the list.
+    Returns a generator of possible retired email addresses based on the
+    original lowercase email and all the historical salts, from oldest to
+    current.  The current salt is assumed to be the last salt in the list.
 
     Raises :class:`~ValueError` if the salt isn't a list of salts.
 
@@ -65,7 +65,7 @@ def get_all_retired_emails(email, salt_list, retired_email_fmt=RETIRED_EMAIL_DEF
         raise SALT_LIST_EXCEPTION
 
     for salt in salt_list:
-        yield retired_email_fmt.format(_compute_retired_hash(email, salt))
+        yield retired_email_fmt.format(_compute_retired_hash(email.lower(), salt))
 
 
 def get_retired_username(username, salt_list, retired_username_fmt=RETIRED_USERNAME_DEFAULT_FMT):
@@ -92,11 +92,11 @@ def get_retired_username(username, salt_list, retired_username_fmt=RETIRED_USERN
 
 def get_retired_email(email, salt_list, retired_email_fmt=RETIRED_EMAIL_DEFAULT_FMT):
     """
-    Returns a retired email address based on the original email address
-    and all the historical salts, from oldest to current.
-    The current salt is assumed to be the last salt in the list.
+    Returns a retired email address based on the original lowercase email
+    address and the current salt. The current salt is assumed to be the last
+    salt in the list.
 
-    Raises :class:`~ValueError` if the salt isn't a list of salts.
+    Raises :class:`~ValueError` if salt_list isn't a list of salts.
 
     Arguments:
         email (str): Email address of the user to be retired.
@@ -104,9 +104,9 @@ def get_retired_email(email, salt_list, retired_email_fmt=RETIRED_EMAIL_DEFAULT_
 
     Yields:
         Returns a retired email address based on the original email
-        and all the historical salts, including the current salt.
+        and the current salt
     """
     if not isinstance(salt_list, (list, tuple)):
         raise SALT_LIST_EXCEPTION
 
-    return retired_email_fmt.format(_compute_retired_hash(email, salt_list[-1]))
+    return retired_email_fmt.format(_compute_retired_hash(email.lower(), salt_list[-1]))


### PR DESCRIPTION
This resolves an issue where account registrations with retired email
addresses are not blocked when the email case is different (but the
email is still the same).

PLAT-2254

---

Tested in devstack.

**Test 1**: created and deleted an account with email `test1@email.com`.  Then I tried to register an account with the email `tEst1@email.com`.

Without this commit, form validation on the email field succeeds, but with this commit, i get the following message:

> It looks like tEst1@email.com belongs to an existing account. Try again with a different email address.

**Test 2**: created and deleted an account with email `tEst2@email.com`.  Then I tried to register an account with the email `test2@email.com`.

> It looks like test2@email.com belongs to an existing account. Try again with a different email address.