### PR TITLE
Add retire_external_key functions into library for usage on program enrollments

### DIFF
--- a/user_util/user_util.py
+++ b/user_util/user_util.py
@@ -6,6 +6,7 @@ import hashlib
 
 RETIRED_USERNAME_DEFAULT_FMT = 'retired_username_{}'
 RETIRED_EMAIL_DEFAULT_FMT = 'retired_email_{}@retired.edx.org'
+RETIRED_EXTERNAL_KEY_DEFAULT_FMT = 'retired_external_key_{}'
 SALT_LIST_EXCEPTION = ValueError("Salt must be a list -or- tuple of all historical salts.")
 
 
@@ -68,6 +69,29 @@ def get_all_retired_emails(email, salt_list, retired_email_fmt=RETIRED_EMAIL_DEF
         yield retired_email_fmt.format(_compute_retired_hash(email.lower(), salt))
 
 
+def get_all_retired_external_keys(external_key, salt_list, retired_external_key_fmt=RETIRED_EXTERNAL_KEY_DEFAULT_FMT):
+    """
+    Returns a generator of possible retired external user key based on the
+    original external user key and all the historical salts, from oldest to
+    current. The current salt is assumed to be the last salt in the list.
+
+    Raises :class:`~ValueError` if the salt isn't a list of salts.
+
+    Arguments:
+        external_key (str): External user key of the user to be retired.
+        salt_list (list/tuple): List of all historical salts.
+
+    Yields:
+        Returns a generator of possible retired external user keys based on the original external key
+        and all the historical salts, including the current salt, from oldest to current.
+    """
+    if not isinstance(salt_list, (list, tuple)):
+        raise SALT_LIST_EXCEPTION
+
+    for salt in salt_list:
+        yield retired_external_key_fmt.format(_compute_retired_hash(external_key.lower(), salt))
+
+
 def get_retired_username(username, salt_list, retired_username_fmt=RETIRED_USERNAME_DEFAULT_FMT):
     """
     Returns a retired username based on the original lowercased username and
@@ -110,3 +134,26 @@ def get_retired_email(email, salt_list, retired_email_fmt=RETIRED_EMAIL_DEFAULT_
         raise SALT_LIST_EXCEPTION
 
     return retired_email_fmt.format(_compute_retired_hash(email.lower(), salt_list[-1]))
+
+
+def get_retired_external_key(external_key, salt_list, retired_external_key_fmt=RETIRED_EXTERNAL_KEY_DEFAULT_FMT):
+    """
+    Returns a retired external user key based on the original external key and the current salt.
+    The current salt is assumed to be the last salt in the list.
+
+    Raises :class:`~ValueError` if salt_list isn't a list of salts.
+
+    Arguments:
+        external_key (str): External user key of the user to be retired.
+        salt_list (list/tuple): List of all historical salts.
+
+    Yields:
+        Returns a retired external user key based on the original external_user_key
+        and the current salt
+    """
+    if not isinstance(salt_list, (list, tuple)):
+        raise SALT_LIST_EXCEPTION
+
+    return retired_external_key_fmt.format(
+        _compute_retired_hash(external_key.lower(), salt_list[-1])
+    )


### PR DESCRIPTION
@edx/masters-devs-cosmonauts @matthugs Please review

This is the first step to retire the external_user_key on program_enrollments table without deleting that external_user_key value.

[MST-418](https://openedx.atlassian.net/browse/MST-418) root cause made me to device this solution. 
We should not have null external_user_key values, we should just retire them how we like to retire username and emails.